### PR TITLE
Add support for storing Speckle credentials in cookies.

### DIFF
--- a/.changeset/bright-clocks-tie.md
+++ b/.changeset/bright-clocks-tie.md
@@ -1,0 +1,5 @@
+---
+'speckle-auth': patch
+---
+
+add support for storing speckle credentials in cookies

--- a/.changeset/bright-clocks-tie.md
+++ b/.changeset/bright-clocks-tie.md
@@ -1,5 +1,0 @@
----
-'speckle-auth': patch
----
-
-add support for storing speckle credentials in cookies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # speckle-auth
 
+## 0.0.8
+
+### Patch Changes
+
+- 24d1171: add support for storing speckle credentials in cookies
+
 ## 0.0.7
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -39,6 +39,23 @@ async function logoutUser() {
 }
 ```
 
+#### Storing Speckle Credentials in cookies
+
+By default, Speckle credentials are stored in local storage.
+If you want to store them in cookies instead, you can set `cookieAppDomain` to the domain of your app.
+This is useful if you want to use the same Speckle credentials across multiple subdomains.
+
+```ts
+import { SpeckleAuthClient, type ApplicationOptions } from 'speckle-auth';
+
+const options: ApplicationOptions = {
+  clientId: 'your-client-id',
+  clientSecret: 'your-client-secret',
+  serverUrl: 'https://app.speckle.systems',
+  cookieAppDomain: 'your-app-domain.com',
+};
+```
+
 ### Logging in with a Personal Access Token (PAT) 🔒🛡️🔑
 
 If you don't want to use OAuth, you can log in with a personal access token instead.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "speckle-auth",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "speckle-auth",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.17.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "speckle-auth",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Utilities for authenticating with the Speckle.",
   "keywords": [
     "speckle",


### PR DESCRIPTION
- Enabled optional `cookieAppDomain` configuration to allow storing credentials in cookies.
- Refactored authentication logic to conditionally utilize either cookies or local storage based on configuration.
- Updated README with usage details for cookie-based authentication.